### PR TITLE
[N/A] Add request/response header size for JettyServer

### DIFF
--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
@@ -576,6 +576,20 @@ object KyuubiConf {
       .timeConf
       .createWithDefaultString("PT5S")
 
+  val FRONTEND_REST_JETTY_HTTP_REQUEST_HEADER_SIZE: ConfigEntry[Int] =
+    buildConf("kyuubi.frontend.rest.jetty.http.request.header.size")
+      .doc("Request header size in bytes.")
+      .version("1.8.1")
+      .intConf
+      .createWithDefault(6144)
+
+  val FRONTEND_REST_JETTY_HTTP_RESPONSE_HEADER_SIZE: ConfigEntry[Int] =
+    buildConf("kyuubi.frontend.rest.jetty.http.response.header.size")
+      .doc("Reponse header size in bytes.")
+      .version("1.8.1")
+      .intConf
+      .createWithDefault(6144)
+
   val FRONTEND_WORKER_KEEPALIVE_TIME: ConfigEntry[Long] =
     buildConf("kyuubi.frontend.worker.keepalive.time")
       .doc("(deprecated) Keep-alive time (in milliseconds) for an idle worker thread")

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiRestFrontendService.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiRestFrontendService.scala
@@ -90,7 +90,9 @@ class KyuubiRestFrontendService(override val serverable: Serverable)
       host,
       port,
       conf.get(FRONTEND_REST_MAX_WORKER_THREADS),
-      conf.get(FRONTEND_REST_JETTY_STOP_TIMEOUT))
+      conf.get(FRONTEND_REST_JETTY_STOP_TIMEOUT),
+      conf.get(FRONTEND_REST_JETTY_HTTP_REQUEST_HEADER_SIZE),
+      conf.get(FRONTEND_REST_JETTY_HTTP_RESPONSE_HEADER_SIZE))
     super.initialize(conf)
   }
 

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/ui/JettyServer.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/ui/JettyServer.scala
@@ -78,7 +78,9 @@ object JettyServer {
       host: String,
       port: Int,
       poolSize: Int,
-      stopTimeout: Long): JettyServer = {
+      stopTimeout: Long,
+      maxRequestSize: Int,
+      maxResponseSize: Int): JettyServer = {
     val pool = new QueuedThreadPool(poolSize)
     pool.setName(name)
     pool.setDaemon(true)
@@ -95,6 +97,8 @@ object JettyServer {
 
     val serverExecutor = new ScheduledExecutorScheduler(s"$name-JettyScheduler", true)
     val httpConf = new HttpConfiguration()
+    httpConf.setRequestHeaderSize(maxRequestSize)
+    httpConf.setResponseHeaderSize(maxResponseSize)
     val connector = new ServerConnector(
       server,
       null,


### PR DESCRIPTION
Proxy 시 사용시 NDC의 헤더가 많아서 header size가 기본값을 넘어갑니다. 
```
2024-03-06 13:32:50.704 KyuubiRestFrontendService-38 DEBUG org.eclipse.jetty.client.HttpSender: Request failure HttpRequest[GET /jobs/ HTTP/1.1]@6a1a792
org.eclipse.jetty.http.BadMessageException: 500: Request header too large
	at org.eclipse.jetty.client.http.HttpSenderOverHTTP$HeadersCallback.process(HttpSenderOverHTTP.java:235) [jetty-client-9.4.52.v20230823.jar:9.4.52.v20230823]
	at org.eclipse.jetty.util.IteratingCallback.processing(IteratingCallback.java:248) [jetty-util-9.4.52.v20230823.jar:9.4.52.v20230823]
	at org.eclipse.jetty.util.IteratingCallback.iterate(IteratingCallback.java:229) [jetty-util-9.4.52.v20230823.jar:9.4.52.v20230823]
	at org.eclipse.jetty.client.http.HttpSenderOverHTTP.sendHeaders(HttpSenderOverHTTP.java:65) [jetty-client-9.4.52.v20230823.jar:9.4.52.v20230823]
```
header 크기를 조절할 수 있는 설정을 추가합니다.

